### PR TITLE
UE4.24.3 - Fixes for successful packaging of plugin

### DIFF
--- a/Source/TPCE/Private/AnimNodes/AnimNode_OrientationWarping.cpp
+++ b/Source/TPCE/Private/AnimNodes/AnimNode_OrientationWarping.cpp
@@ -4,7 +4,8 @@
 #include "AnimationRuntime.h"
 #include "Animation/AnimInstanceProxy.h"
 
-FAnimMode_OrientationWarping::FAnimMode_OrientationWarping()
+FAnimMode_OrientationWarping::FAnimMode_OrientationWarping():
+	LocomotionAngle(0.f)
 {
 }
 

--- a/Source/TPCE/Private/AnimNodes/AnimNode_SpeedWarping.cpp
+++ b/Source/TPCE/Private/AnimNodes/AnimNode_SpeedWarping.cpp
@@ -14,6 +14,8 @@ DECLARE_CYCLE_STAT(TEXT("SpeedWarping Eval"), STAT_SpeedWarping_Eval, STATGROUP_
 FAnimNode_SpeedWarping::FAnimNode_SpeedWarping()
 	: Space(EBoneControlSpace::BCS_BoneSpace)
 	, Direction(FVector::RightVector)
+	, SpeedScaling(1.0f)
+	, PelvisOffset(FVector::ZeroVector)
 	, PelvisInterpSpeed(10.f)
 	, PelvisAdjustmentAlpha(1.0f)
 	, bClampIKUsingFKLeg(true)

--- a/Source/TPCE/Private/Components/ActorWidgetComponent.cpp
+++ b/Source/TPCE/Private/Components/ActorWidgetComponent.cpp
@@ -21,7 +21,7 @@ UActorWidgetComponent::UActorWidgetComponent()
 
 #if WITH_EDITOR
 
-bool UActorWidgetComponent::CanEditChange(const UProperty* InProperty) const
+bool UActorWidgetComponent::CanEditChange(const FProperty* InProperty) const
 {
 	bool bCanChange = Super::CanEditChange(InProperty);
 
@@ -54,7 +54,7 @@ void UActorWidgetComponent::PostEditChangeProperty(struct FPropertyChangedEvent&
 				OnVisibilityChanged();
 	}
 
-	// Note: Any changes must be made before UActorComponent::PostEditChangeChainProperty is called because components will be reset when UActorComponent reruns construction scripts 
+	// Note: Any changes must be made before UActorComponent::PostEditChangeChainProperty is called because components will be reset when UActorComponent reruns construction scripts
 	Super::PostEditChangeProperty(e);
 }
 #endif

--- a/Source/TPCE/Private/GameFramework/ExtCharacter.cpp
+++ b/Source/TPCE/Private/GameFramework/ExtCharacter.cpp
@@ -405,12 +405,22 @@ void AExtCharacter::PreReplication(IRepChangedPropertyTracker & ChangedPropertyT
 	// Workaround:: Skip original ReplicatedMovement if the custom tailored one can be used.
 	if (IsReplicatingMovement() || GetAttachmentReplication().AttachParent)
 	{
+
+
+
 		if (GatherExtMovement())
 		{
 			DOREPLIFETIME_ACTIVE_OVERRIDE(AExtCharacter, ReplicatedExtMovement, IsReplicatingMovement());
-			PRAGMA_DISABLE_DEPRECATION_WARNINGS
+			{
+				/* UE4.25 Replicated Movement is private we need a workaround
+				PRAGMA_DISABLE_DEPRECATION_WARNINGS
 				DOREPLIFETIME_ACTIVE_OVERRIDE(AActor, ReplicatedMovement, false);
-			PRAGMA_ENABLE_DEPRECATION_WARNINGS
+				PRAGMA_ENABLE_DEPRECATION_WARNINGS
+				*/
+				static const FName ReplicatedMovementPropertyName(TEXT("ReplicatedMovement"));
+				static UProperty* ReplicatedMovementProperty = GetReplicatedProperty(StaticClass(),ACharacter::StaticClass(),ReplicatedMovementPropertyName);
+				ChangedPropertyTracker.SetCustomIsActiveOverride(this,ReplicatedMovementProperty->RepIndex,false);
+			}
 		}
 		else
 		{
@@ -421,9 +431,17 @@ void AExtCharacter::PreReplication(IRepChangedPropertyTracker & ChangedPropertyT
 	else
 	{
 		DOREPLIFETIME_ACTIVE_OVERRIDE(AExtCharacter, ReplicatedExtMovement, false);
-		PRAGMA_DISABLE_DEPRECATION_WARNINGS
+
+		{
+			/* UE4.25 Replicated Movement is private we need a workaround
+			PRAGMA_DISABLE_DEPRECATION_WARNINGS
 			DOREPLIFETIME_ACTIVE_OVERRIDE(AActor, ReplicatedMovement, false);
-		PRAGMA_ENABLE_DEPRECATION_WARNINGS
+			PRAGMA_ENABLE_DEPRECATION_WARNINGS
+			*/
+			static const FName ReplicatedMovementPropertyName(TEXT("ReplicatedMovement"));
+			static UProperty* ReplicatedMovementProperty = GetReplicatedProperty(StaticClass(), ACharacter::StaticClass(), ReplicatedMovementPropertyName);
+			ChangedPropertyTracker.SetCustomIsActiveOverride(this,ReplicatedMovementProperty->RepIndex, false);
+		}
 	}
 
 	// Workaround: Disable replication of ReplicatedMovementMode since we have a custom movement mode replication that includes jump state info.
@@ -432,7 +450,7 @@ void AExtCharacter::PreReplication(IRepChangedPropertyTracker & ChangedPropertyT
 	{
 		static const FName ReplicatedMovementModePropertyName(TEXT("ReplicatedMovementMode"));
 		static UProperty* ReplicatedMovementModeProperty = GetReplicatedProperty(StaticClass(), ACharacter::StaticClass(), ReplicatedMovementModePropertyName);
-		ChangedPropertyTracker.SetCustomIsActiveOverride(ReplicatedMovementModeProperty->RepIndex, false);
+		ChangedPropertyTracker.SetCustomIsActiveOverride(this,ReplicatedMovementModeProperty->RepIndex, false);
 	}
 
 	// Workaround: RemoteViewPitch is taken from ReplicatedLook.Rotation.Pitch

--- a/Source/TPCE/Private/GameFramework/ExtCharacter.cpp
+++ b/Source/TPCE/Private/GameFramework/ExtCharacter.cpp
@@ -243,7 +243,7 @@ AExtCharacter::AExtCharacter(const FObjectInitializer& ObjectInitializer)
 	ExtCharacterMovement->ResetExtraMoveState();
 
 	ExtCharacterMovement->bUseVelocityAsMovementVector = true;
-	
+
 	ExtCharacterMovement->CrouchedHalfHeight = 60.0f;
 	ExtCharacterMovement->SetWalkableFloorAngle(50.0f);
 
@@ -370,7 +370,7 @@ AExtCharacter::AExtCharacter(const FObjectInitializer& ObjectInitializer)
 	ExtCharacterMovement->NetworkSimulatedSmoothRotationTime = 0.05f;
 	ExtCharacterMovement->ListenServerNetworkSimulatedSmoothRotationTime = 0.05f;
 
-	// Note: The skeletal mesh and anim blueprint references on the Mesh component (inherited from Character) 
+	// Note: The skeletal mesh and anim blueprint references on the Mesh component (inherited from Character)
 	// must be set in the derived blueprint assets to avoid direct content references in C++.
 }
 
@@ -445,7 +445,7 @@ void AExtCharacter::PreReplication(IRepChangedPropertyTracker & ChangedPropertyT
 	}
 
 	// Workaround: Disable replication of ReplicatedMovementMode since we have a custom movement mode replication that includes jump state info.
-	// Cannot use DOREPLIFETIME_ACTIVE_OVERRIDE(ACharacter, ReplicatedMovementMode, false) here because GET_MEMBER_NAME_CHECKED does not support 
+	// Cannot use DOREPLIFETIME_ACTIVE_OVERRIDE(ACharacter, ReplicatedMovementMode, false) here because GET_MEMBER_NAME_CHECKED does not support
 	// protected/private members.
 	{
 		static const FName ReplicatedMovementModePropertyName(TEXT("ReplicatedMovementMode"));
@@ -546,7 +546,7 @@ bool AExtCharacter::GatherExtMovement()
 			ReplicatedExtMovement.Location = RootComponent->GetComponentLocation();
 			ReplicatedExtMovement.Rotation = RootComponent->GetComponentRotation();
 			ReplicatedExtMovement.Velocity = ExtCharacterMovement->Velocity;
-			ReplicatedExtMovement.Acceleration = ExtCharacterMovement->GetCurrentAcceleration().GetSafeNormal();			
+			ReplicatedExtMovement.Acceleration = ExtCharacterMovement->GetCurrentAcceleration().GetSafeNormal();
 			ReplicatedExtMovement.bIsPivotTurning = ExtCharacterMovement->IsPivotTurning();
 			ReplicatedExtMovement.TurnInPlaceTargetYaw = ExtCharacterMovement->GetTurnInPlaceTargetYaw();
 
@@ -666,7 +666,7 @@ void AExtCharacter::OnRep_IsPerformingGenericAction()
 
 #if WITH_EDITOR
 
-bool AExtCharacter::CanEditChange(const UProperty* InProperty) const
+bool AExtCharacter::CanEditChange(const FProperty* InProperty) const
 {
 	bool bCanChange = Super::CanEditChange(InProperty);
 
@@ -715,7 +715,7 @@ void AExtCharacter::PostEditChangeProperty(struct FPropertyChangedEvent& e)
 				UpdateDebugComponentsVisibility();
 	}
 
-	// Note: Any changes must be made before AActor::PostEditChangeChainProperty is called because components will be reset when UActorComponent reruns construction scripts 
+	// Note: Any changes must be made before AActor::PostEditChangeChainProperty is called because components will be reset when UActorComponent reruns construction scripts
 	Super::PostEditChangeProperty(e);
 }
 
@@ -812,7 +812,7 @@ void AExtCharacter::Tick(float DeltaTime)
 
 		if (USkeletalMeshComponent* MyMesh = GetMesh())
 		{
-			const UWorld* World = GetWorld();	
+			const UWorld* World = GetWorld();
 			const FTransform& RootBoneTransform = GetMesh()->GetBoneTransform(0);
 			const FVector RootBoneLocation = RootBoneTransform.GetLocation();
 			const FRotator RootBoneRotation = RootBoneTransform.Rotator();
@@ -832,7 +832,7 @@ void AExtCharacter::Tick(float DeltaTime)
 
 			const FVector Direction = GetActorForwardVector();
 			const float Aperture = ExtCharacterMovement->LookAngleThreshold;
-			DrawDebugCone(World, Location, Direction, 100.0f, FMath::DegreesToRadians(Aperture), 0.0f, Aperture / 5.f, FColor::Cyan, false, -1.0f, SDPG_Foreground);			
+			DrawDebugCone(World, Location, Direction, 100.0f, FMath::DegreesToRadians(Aperture), 0.0f, Aperture / 5.f, FColor::Cyan, false, -1.0f, SDPG_Foreground);
 		}
 	}
 #endif
@@ -1258,7 +1258,7 @@ void AExtCharacter::OnMovementModeChanged(EMovementMode PrevMovementMode, uint8 
 
 void AExtCharacter::OnMovementModeChanged(EMovementMode PrevMovementMode, EMovementMode CurrentMovementMode, uint8 PrevCustomMovementMode, uint8 CurrentCustomMovementMode)
 {
-	
+
 }
 
 void AExtCharacter::OnCrouchedChanged()
@@ -1821,7 +1821,7 @@ void AExtCharacter::OnStartRagdoll()
 		if (IsLanding())
 			CancelLanding();
 	}
-	
+
 	// Ragdolls don't rotate
 	ExtCharacterMovement->ResetTurnInPlaceState();
 	ExtCharacterMovement->ResetControllerDesireRotationState();
@@ -1902,7 +1902,7 @@ void AExtCharacter::SetGait(ECharacterGait NewGait)
 // 	{
 // 		return GetRootComponent()->GetComponentVelocity().GetSafeNormal();
 // 	}
-// 
+//
 // 	const UCharacterMovementComponent* CharacterMovement = GetCharacterMovement();
 // 	return CharacterMovement ? CharacterMovement->GetCurrentAcceleration() : FVector::ZeroVector;
 // }

--- a/Source/TPCE/Private/GameFramework/ExtCharacterMovementComponent.cpp
+++ b/Source/TPCE/Private/GameFramework/ExtCharacterMovementComponent.cpp
@@ -460,7 +460,7 @@ void UExtCharacterMovementComponent::OnMovementUpdated(float DeltaSeconds, const
 
 	check(ExtCharacterOwner);
 
-#if WITH_EDITOR
+#if WITH_EDITORONLY_DATA
 	// Square roots for PIE
 	InEditorSpeed = Velocity.Size();
 	InEditorGroundSpeed = Velocity.Size2D();

--- a/Source/TPCE/Public/Components/ActorWidgetComponent.h
+++ b/Source/TPCE/Public/Components/ActorWidgetComponent.h
@@ -43,7 +43,7 @@ public:
 	void SetAutoAssignPlayer(EAutoReceiveInput::Type PlayerIndex);
 
 #if WITH_EDITOR
-	virtual bool CanEditChange(const UProperty* InProperty) const override;
+	virtual bool CanEditChange(const FProperty* InProperty) const override;
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& e) override;
 #endif
 

--- a/Source/TPCE/Public/GameFramework/ExtCharacter.h
+++ b/Source/TPCE/Public/GameFramework/ExtCharacter.h
@@ -32,7 +32,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FRagdollChangedSignature, AExtCharac
 // ---------------------------------
 // TODO: Comment all methods with All/Local/Server to indicate where they are expected to be called
 // TODO: Add missing comments/tooltips to members
-// TODO: Try to improve the movement blend with a walk-in-place animation for gait scale 0. This should reduce leg crossing. 
+// TODO: Try to improve the movement blend with a walk-in-place animation for gait scale 0. This should reduce leg crossing.
 // TODO: Idle Breaks
 // TODO: Female animations
 // TODO: Better crouch animations
@@ -118,10 +118,10 @@ struct FCharacterMovementSettings
 
 /**
  * An extended Character that can Walk, Run, Sprint, Crouch, Jump, Perform a generic action and turn into a Ragdoll.
- * The default gait is Run. 
+ * The default gait is Run.
  *
  * Characters of this class can assume one of two attitudes with distinct movement settings. Normally the character will be in its Primary attitude.
- * When the generic action is activated it then assumes the Secondary attitude. 
+ * When the generic action is activated it then assumes the Secondary attitude.
  *
  * Neither Crouch, Jump nor the generic action can be performed while the character is Sprinting.
  *
@@ -158,7 +158,7 @@ struct FCharacterMovementSettings
  * This means no camera component or camera dependent properties. Anything camera related should be implemented by derived classes.
  *
  * NOTE: We don't cache the "last hit" in CharacterMovement, and there maybe multiple hits per simulation step, but there are a variety of ways
- * to get notifications for such events (called in this order). 
+ * to get notifications for such events (called in this order).
  *     - virtual AActor::NotifyHit()
  *     - (Actor Blueprint Event) EventHit (called by NotifyHit())
  *     - virtual UCharacterMovementComponent::HandleImpact()
@@ -174,7 +174,7 @@ class TPCE_API AExtCharacter : public ACharacter
 	GENERATED_BODY()
 
 public:
-	
+
 	AExtCharacter(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
 
 protected:	// Bitfields
@@ -432,7 +432,7 @@ private:	// Methods
 	 * @see OnLandingComplete()
 	 */
 	void LandingTimer_OnTime();
-	
+
 
 	/**
 	* Callback for the GettingUpTimer. Calls OnGettingUpComplete() without the risk of being overriden by derived classes.
@@ -671,7 +671,7 @@ public:		// Methods
 	virtual void PostNetReceive() override;
 
 #if WITH_EDITOR
-	virtual bool CanEditChange(const UProperty* InProperty) const override;
+	virtual bool CanEditChange(const FProperty* InProperty) const override;
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& e) override;
 #endif
 
@@ -713,7 +713,7 @@ public:		// Methods
 	virtual void OnJumped_Implementation();
 
 
-	/** 
+	/**
 	 * @return true if this character is currently able to crouch (and is not currently crouched). This method was made final for consistency.
 	 * @see CanCrouchInternal()
 	 */

--- a/Source/TPCE/Public/GameFramework/ExtCharacterMovementComponent.h
+++ b/Source/TPCE/Public/GameFramework/ExtCharacterMovementComponent.h
@@ -216,7 +216,7 @@ public: // Bitfields
 
 private: // Variables
 
-#if WITH_EDITOR
+#if WITH_EDITORONLY_DATA
 
 	/** Current Speed */
 	UPROPERTY(VisibleInstanceOnly, Transient, DuplicateTransient, Category = Velocity, meta=(DisplayName="Speed"))

--- a/Source/TPCE/Public/Math/Bounds.h
+++ b/Source/TPCE/Public/Math/Bounds.h
@@ -24,9 +24,9 @@ struct TPCE_API FBounds
 
 public:
 
-	FORCEINLINE FBounds();
-	FORCEINLINE FBounds(float InMin, float InUpperBound);
-	FORCEINLINE FBounds(const FBounds& Other);
+	FBounds();
+	FBounds(float InMin, float InUpperBound);
+	FBounds(const FBounds& Other);
 
 	FORCEINLINE explicit FBounds(const FVector2D& Other);
 

--- a/Source/TPCE/TPCE.Build.cs
+++ b/Source/TPCE/TPCE.Build.cs
@@ -24,7 +24,8 @@ public class TPCE: ModuleRules
 				"Engine",
 				"AnimationCore",
 				"AnimGraphRuntime",
-				"InputCore"
+				"InputCore",
+				"AIModule"
 			}
 		);
 

--- a/Source/TPCEEditor/Private/TPCEEditor.cpp
+++ b/Source/TPCEEditor/Private/TPCEEditor.cpp
@@ -104,7 +104,10 @@ void FTPCEEditor::ShutdownModule()
 	}
 	else 
 	{
+//Error due to GUnrealEd being NULL causes packaging failure
+#if !UE_BUILD_SHIPPING && !UE_BUILD_DEVELOPMENT
 		UE_LOG(LogTPCEEditor, Error, TEXT("Cannot unregister component visualizers: GUnrealEd is null."));
+#endif
 	}
 
 	UnregisterAssetTools();
@@ -174,7 +177,10 @@ void FTPCEEditor::RegisterComponentVisualizer(const FName ComponentClassName, TS
 	}
 	else
 	{
+//Error due to GUnrealEd being NULL causes packaging failure
+#if !UE_BUILD_SHIPPING && !UE_BUILD_DEVELOPMENT
 		UE_LOG(LogTPCEEditor, Error, TEXT("Cannot register component visualizers: GUnrealEd is null."));
+#endif
 	}
 
 	RegisteredComponentClassNames.Add(ComponentClassName);

--- a/TPCE.uplugin
+++ b/TPCE.uplugin
@@ -11,7 +11,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "https://github.com/nlebedenco/TCPE/issues",
-	"EngineVersion": "4.24.0",
+	"EngineVersion": "4.25.0",
 	"EnabledByDefault": false,
 	"CanContainContent": true,
 	"Modules": [


### PR DESCRIPTION
**Fixes for warnings and critical issuing when packaging plugin.**

**Warnings:**

- Fixed warnings for uninitialized members in AnimNodes


**Critical:**

- Movement Comp WITH_EDITOR members replaced WITH_EDITORONLY_DATA. Unknown but critical issue.

- FORCEINLINE constructors not implemented inline. Removed FORCEINLINE, might just move the implementation to the header instead.

- AIModule required for PathfollowingComponent in ExtCharMovementComp

- Error logging in Editor Module Casues Packaging to fail. Only Relevant in Editor builds but packaging will still fail in development and shipping when log error is encountered. Wrapped in preprocessor macros for current build type
